### PR TITLE
Correct rdflib.js path

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "homepage": "https://github.com/linkeddata/mashlib",
   "dependencies": {
+    "http-browserify": "^1.7.0",
     "rdflib": "git://github.com/linkeddata/rdflib.js.git",
     "solid-ui": "git://github.com/linkeddata/solid-ui.git",
     "solid-app-set": "https://github.com/linkeddata/solid-app-set.git"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "homepage": "https://github.com/linkeddata/mashlib",
   "dependencies": {
-    "rdflib": "git://github.com/linkeddata/rdflib.git",
+    "rdflib": "git://github.com/linkeddata/rdflib.js.git",
     "solid-ui": "git://github.com/linkeddata/solid-ui.git",
     "solid-app-set": "https://github.com/linkeddata/solid-app-set.git"
   },


### PR DESCRIPTION
This pull request fixes the `npm install` failure because of an incorrect rdflib.js path.