### PR TITLE
Avoid pushState errors

### DIFF
--- a/static/browse.html
+++ b/static/browse.html
@@ -24,7 +24,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
       const params = new URLSearchParams(location.search)
       params.set('uri', uri);
-      window.history.replaceState({}, '', `${location.pathname}?${params}`);
+      window.history.replaceState({}, '', `${location.origin}${location.pathname}?${params}`);
 
       var subject = kb.sym(uri);
       // UI.widgets.makeDraggable(icon, subject) // beware many handlers piling up


### PR DESCRIPTION
If we don't include the origin, we get an origin mismatch between the old state and the new one.