### PR TITLE
relative path approach

### DIFF
--- a/static/browse.html
+++ b/static/browse.html
@@ -13,8 +13,8 @@
       }
     }, true);
   </script>
-  <link type="text/css" rel="stylesheet" href="mash.css" />
-  <script type="text/javascript" src="mashlib.js"></script>
+  <link type="text/css" rel="stylesheet" href="./mash.css" />
+  <script type="text/javascript" src="./mashlib.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
     const authn = SolidLogic.authn

--- a/webpack.config.mjs
+++ b/webpack.config.mjs
@@ -23,9 +23,7 @@ const common = {
     target: 'web',
     output: {
       path: path.resolve(process.cwd(), 'dist'),
-      // 'auto' determines the public path at runtime based on the script's location
-      // This works for both the HTML file and dynamically loaded chunks
-      publicPath: 'auto',
+      publicPath: '',
       library: {
         name: 'Mashlib',
         type: 'umd'


### PR DESCRIPTION
The issue is that you need different publicPaths for different deployments. The solution is to use relative paths in the HTML and set publicPath: '':

Now with publicPath:'' and relative paths (./mashlib.js), the chunks will load relative to wherever the HTML file is:

✅ http://alice.localhost:3000/browse.html → loads ./mashlib.js and ./841.mashlib.js
✅ https://solidos.github.io/mashlib/dist/browse.html → loads ./mashlib.js and ./841.mashlib.js
Rebuild with npm run build and both scenarios should work!


With publicPath: '', HtmlWebpackPlugin will inject <script src="mashlib.min.js"></script> (relative path without the ./ prefix, which is equivalent).

The generated [databrowser.html](vscode-file://vscode-app/c:/Users/alain/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) will have relative paths for all assets, just like browse.html now does. Both work the same way.With [publicPath: ''](vscode-file://vscode-app/c:/Users/alain/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), HtmlWebpackPlugin will inject <script src="mashlib.min.js"></script> (relative path without the ./ prefix, which is equivalent).

The generated databrowser.html will have relative paths for all assets, just like browse.html now does. Both work the same way.

Claude Son