### PR TITLE
New layout

### DIFF
--- a/src/databrowser.html
+++ b/src/databrowser.html
@@ -82,10 +82,6 @@
         <div id="MenuOverlay" class="menu-overlay" hidden aria-hidden="true"></div>
         </div>
 
-        <!-- Footer — populated by solid-ui initFooter() -->
-        <footer id="PageFooter" role="contentinfo">
-        <!-- solid-ui injects: "Powered by Solid" link -->
-        </footer>
     </solid-ui-provider>
   </body>
 </html>

--- a/src/databrowser.html
+++ b/src/databrowser.html
@@ -43,9 +43,6 @@
         <!-- Main content area — single visible region at a time -->
         <div class="app-main" tabindex="-1" aria-live="polite">
         <div class="app-shell">
-            <aside id="NavMenu" class="app-nav" aria-label="Application menu" hidden>
-            <div id="NavMenuContent" class="menu-content"></div>
-            </aside>
 
             <main id="MainContent" class="app-view">
             <!--
@@ -78,9 +75,6 @@
             </section>
             </main> <!-- .app-view -->
         </div> <!-- .app-shell -->
-
-        <div id="MenuOverlay" class="menu-overlay" hidden aria-hidden="true"></div>
-        </div>
 
     </solid-ui-provider>
   </body>

--- a/static/browse-test.html
+++ b/static/browse-test.html
@@ -137,7 +137,6 @@ document.addEventListener('DOMContentLoaded', function() {
 
   </main>
 
-  <footer id="PageFooter" role="contentinfo"></footer>
   <style>
     body {
       padding-top: calc(var(--browse-header-offset, var(--app-header-height, 3.8rem)) + 0.35rem);

--- a/static/browse.html
+++ b/static/browse.html
@@ -138,7 +138,6 @@ document.addEventListener('DOMContentLoaded', function() {
 
     </main>
 
-    <footer id="PageFooter" role="contentinfo"></footer>
   </solid-ui-provider>
 
   <style>


### PR DESCRIPTION
Remove the left-side menu and footer, according to new design.
Menu was shifted under logged inn user icon.