### PR TITLE
Change for solid-logic after migration to Vite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.2.3-3",
       "license": "MIT",
       "dependencies": {
-        "pane-registry": "3.1.2-1",
+        "pane-registry": "3.1.2-2",
         "patch-package": "^8.0.1",
         "rdflib": "2.4.0",
         "solid-logic": "4.0.8-1",
@@ -3888,9 +3888,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.41",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.41.tgz",
-      "integrity": "sha512-WwS7MHhqGHHlaVsqRZnhvCEMS0owDX+SxRlve7JkuH7My1Ara3ZriTmCQupPfYjxMZ8I/tgxtJYr2t7taHaH4A==",
+      "version": "2.10.42",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
+      "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -5561,9 +5561,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.385",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.385.tgz",
-      "integrity": "sha512-78sa/M08MNAYHQfjoWMvOlKQqZ0ElhSm/L5HNUc96VZ3b+KvDVnngFm8sYQy0XrhTRgAhggHr5abA7yTvRdo4Q==",
+      "version": "1.5.387",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.387.tgz",
+      "integrity": "sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -8682,9 +8682,9 @@
       }
     },
     "node_modules/n3": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/n3/-/n3-2.1.0.tgz",
-      "integrity": "sha512-+05H/h40wRyROglcVGrNZAwBu0Nc87luKhiTV95aGBGX1YyITtpwftHwyhT5YoZr4soXJWrzxqC1CHPdGqV63g==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-2.1.1.tgz",
+      "integrity": "sha512-kqg8ers6Lc+uAmHeS+ycd3b8mC4x8wr8V8Fi6+w7l4hX6b0KZ5bT05Tf49qM2mujwaqZT3+08zcgtXgfxivbVQ==",
       "license": "MIT",
       "dependencies": {
         "buffer": "^6.0.3",
@@ -9258,10 +9258,14 @@
       "license": "(MIT AND Zlib)"
     },
     "node_modules/pane-registry": {
-      "version": "3.1.2-1",
-      "resolved": "https://registry.npmjs.org/pane-registry/-/pane-registry-3.1.2-1.tgz",
-      "integrity": "sha512-aibuyF8pAgHDnmywsMEKUddIcqC0oPF8fNx2TP7zRpRW9aYk2iv06td+br8wenbmu2V/l6Y6aJmCkckHWN/GpA==",
-      "license": "MIT"
+      "version": "3.1.2-2",
+      "resolved": "https://registry.npmjs.org/pane-registry/-/pane-registry-3.1.2-2.tgz",
+      "integrity": "sha512-w+pCan1Umj+pLm5/uNlBMLw0YOKbKhHn5Qh62oqlKlbFrSHj4H3gNOXcKnI47liQFPQYepw5UPssP3aPdiowvA==",
+      "license": "MIT",
+      "dependencies": {
+        "rdflib": "2.4.0",
+        "solid-logic": "4.0.8-1"
+      }
     },
     "node_modules/param-case": {
       "version": "3.0.4",
@@ -12152,9 +12156,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/webpack": {
-      "version": "5.108.3",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.108.3.tgz",
-      "integrity": "sha512-hOpaCHmQVVY66IVTjofnH14IgSdmod2aquSGHGuYig/OIdWge01Hk2Wt988DZcwXumFUT4+FvJY5N+ikl8o/ww==",
+      "version": "5.108.4",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.108.4.tgz",
+      "integrity": "sha512-yur8LyJoeiWh47dErD+Ok7vlbmDsJ3UbbRPAoxbGJ54WpE2y5yVo5G/inUzujnYgw3tPmBRdn+G7PoxXaYC33w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12198,9 +12202,9 @@
       }
     },
     "node_modules/webpack-cli": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-7.1.0.tgz",
-      "integrity": "sha512-pSJ5p5PkXRD88sfCq5Wo+coc42QykwRu5Md0DyESj0rT6PPPA2wTNabpHPKgqH8EMkfTDo3IWx3iiNXMu8XDBQ==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-7.2.1.tgz",
+      "integrity": "sha512-YwSGbcZdfz12DM8JIseVPr3oBb09IgVCVc4vY3oDvZnI/mALTGPAP1QiqOi4/bBLSJrRHaqDIXeHcNA0+G38aw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12229,7 +12233,7 @@
         "toml": "^3.0.0 || ^4.0.0",
         "webpack": "^5.101.0",
         "webpack-bundle-analyzer": "^4.0.0 || ^5.0.0",
-        "webpack-dev-server": "^5.0.0"
+        "webpack-dev-server": "^5.0.0 || ^6.0.0"
       },
       "peerDependenciesMeta": {
         "js-yaml": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "homepage": "https://github.com/solidos/mashlib",
   "dependencies": {
-    "pane-registry": "3.1.2-1",
+    "pane-registry": "3.1.2-2",
     "patch-package": "^8.0.1",
     "rdflib": "2.4.0",
     "solid-logic": "4.0.8-1",

--- a/src/styles/themes/dark.css
+++ b/src/styles/themes/dark.css
@@ -173,8 +173,6 @@ html[data-theme="dark"] {
   --color-sort-arrow: #555;
   
   /* Typography */
-  --font-family-base: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-  --font-family-ui: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   --font-size-base: 100%;
   --font-size-strong: 120%;
   --font-weight-normal: normal;

--- a/webpack.config.mjs
+++ b/webpack.config.mjs
@@ -11,11 +11,11 @@ const WORKSPACE_RESOLUTION_MODE = 'workspace'
 
 const packageAliases = {
   'rdflib': path.resolve('./node_modules/rdflib'),
-  'solid-logic': path.resolve('./node_modules/solid-logic'),
+  'solid-logic': path.resolve('./node_modules/solid-logic/dist/index.cjs.js'),
   'UI$': path.resolve('./node_modules/solid-ui/dist/index.esm.js'),
   'pane-registry': path.resolve('./node_modules/pane-registry'),
   '$rdf': path.resolve('./node_modules/rdflib'),
-  'SolidLogic': path.resolve('./node_modules/solid-logic')
+  'SolidLogic': path.resolve('./node_modules/solid-logic/dist/index.cjs.js')
 }
 
 const workspaceAliases = {


### PR DESCRIPTION
The file is no longer solid-logic it's solid-logic.cjs.js needed to change the package for solid-logic. Perhaps I should have changed to solid-logic.esm.js though?

I made a mistake when commiting the work. i thought i committed it but didn't... anyway in the end i accidently amended the last commit of staging so that's why that file is in here.

I'm not sure what to do or if it matters... i think the commit hash just changed not the content.

Also, I'm not sure how to link this, it needs to merge after this one https://github.com/SolidOS/solid-logic/pull/315 otherwise solidos will stop working when pulling down staging.